### PR TITLE
bump portage version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ language: python
 python:
     - pypy
 env:
-    - PORTAGE_VER="2.2.20"
+    - PORTAGE_VER="2.2.20.1"
 before_script:
     - mkdir travis-overlay
     - mv !(travis-overlay) travis-overlay/


### PR DESCRIPTION
this portage should not complain about `Malformed CVS Header on line: 3` for new ebuilds with Id headers (after migration to git)