### PR TITLE
.travis.yml: Enable shopt -s extglob, prevents error in shippable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 #
-# Run repoman via travis
+# Run repoman via travis (or shippable)
 # See https://github.com/mrueg/repoman-travis
 #
 language: python
@@ -12,6 +12,7 @@ before_install:
     - pip install lxml
 before_script:
     - mkdir travis-overlay
+    - shopt -s extglob
     - mv !(travis-overlay) travis-overlay/
     - mv .git travis-overlay/
     - wget "https://raw.githubusercontent.com/mrueg/repoman-travis/master/.travis.yml" -O .travis.yml.upstream


### PR DESCRIPTION
Added option to enable extglob shell option. This prevents error in shippable. Otherwise shippable reads travis.yml and works 👍 

Error
```
mv !(travis-overlay) travis-overlay/ 0s  
/root/1ddf83e9-4bc8-45fe-8515-3084707bca9c.sh: eval: line 58: syntax error near unexpected token `('
/root/1ddf83e9-4bc8-45fe-8515-3084707bca9c.sh: eval: line 58: `mv !(travis-overlay) travis-overlay/'
```