### PR TITLE
.travis.yml: switch to a real profile: default/linux/amd64/13.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_script:
     - echo "portage::250:portage,travis" >> /etc/group
     - wget "https://www.gentoo.org/dtd/metadata.dtd" -O /usr/portage/distfiles/metadata.dtd
     - ln -s portage-portage-${PORTAGE_VER}/cnf/repos.conf /etc/portage/repos.conf
-    - ln -s /usr/portage/profiles/base/ /etc/portage/make.profile
+    - ln -s /usr/portage/profiles/default/linux/amd64/13.0 /etc/portage/make.profile
     - SIZE=$(stat -c %s .travis.yml.upstream)
     - if ! cmp -n $SIZE -s .travis.yml .travis.yml.upstream; then echo -e "\e[31m !!! .travis.yml outdated! Update available https://github.com/mrueg/repoman-travis \e[0m" > /tmp/update ; fi
     - cd travis-overlay


### PR DESCRIPTION
https://gitweb.gentoo.org/repo/gentoo.git/commit/?id=66b9feb7fb6fd56594f9dab7f9f5e85b8fe3cf20
moved USE_EXPAND_VALUES_ARCH from
    profiles/base
to
    profiles/arch/base

It's not clear why a profile is relevant for repoman at all.
Filed https://bugs.gentoo.org/610880 to investigate.

Meanwhile this change workarounds breakages in form of:
  https://travis-ci.org/gentoo-haskell/gentoo-haskell/builds/205244507
    IUSE.missing [fatal]
      dev-lang/ghc/ghc-7.8.4.ebuild: SRC_URI: USE flag 'alpha' referenced in conditional 'alpha?' is not in IUSE
  https://travis-ci.org/Obsidian-StudiosInc/os-xtoo/builds/204736837
    IUSE.missing [fatal]
       dev-java/oracle-jdk-bin/oracle-jdk-bin-9_pre157.ebuild: SRC_URI: USE flag 'amd64' referenced in conditional 'amd64?' is not in IUSE

Bug: https://bugs.gentoo.org/610880
Signed-off-by: Sergei Trofimovich <slyfox@gentoo.org>