### PR TITLE
Make update check use diff without comments/whitespace

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,8 @@ before_script:
     - mkdir -p travis-overlay /etc/portage /usr/portage/distfiles
     - mv !(travis-overlay) travis-overlay/
     - mv .git travis-overlay/
-    - wget "https://raw.githubusercontent.com/mrueg/repoman-travis/master/.travis.yml" -O .travis.yml.upstream
+    - curl "https://raw.githubusercontent.com/mrueg/repoman-travis/master/.travis.yml" | grep -v "^#" > .travis.yml.upstream
+    - grep -v "^#" .travis.yml > .travis.yml.local
     - wget "https://raw.githubusercontent.com/mrueg/repoman-travis/master/spinner.sh"
     - wget -qO - "https://github.com/gentoo/portage/archive/portage-${PORTAGE_VER}.tar.gz" | tar xz
     - wget -qO - "https://github.com/gentoo-mirror/gentoo/archive/master.tar.gz" | tar xz -C /usr/portage --strip-components=1
@@ -25,8 +26,8 @@ before_script:
     - wget "https://www.gentoo.org/dtd/metadata.dtd" -O /usr/portage/distfiles/metadata.dtd
     - ln -s portage-portage-${PORTAGE_VER}/cnf/repos.conf /etc/portage/repos.conf
     - ln -s /usr/portage/profiles/default/linux/amd64/13.0 /etc/portage/make.profile
-    - SIZE=$(stat -c %s .travis.yml.upstream)
-    - if ! cmp -n $SIZE -s .travis.yml .travis.yml.upstream; then echo -e "\e[31m !!! .travis.yml outdated! Update available https://github.com/mrueg/repoman-travis \e[0m" > /tmp/update ; fi
+    - echo
+    - if [ "$(diff -w .travis.yml.local .travis.yml.upstream | wc -l)" -gt 0 ]; then echo -e "\e[31m !!! .travis.yml outdated! Update available https://github.com/mrueg/repoman-travis \e[0m" > /tmp/update ; fi
     - cd travis-overlay
 script:
     - ./../spinner.sh "python ../portage-portage-${PORTAGE_VER}/repoman/bin/repoman full -d"


### PR DESCRIPTION
This change allows people to change the comments on the `.travis.yaml` file. The `diff` ignores whitespace changes as well, so people can use their preferred indentation style as well.

Personally, I'd like to add a `.travis.d` directory to put the scripts in like the update checker, and allow custom scripts to be dropped in such a directory too. I can add that as well, if you were to agree on this.