### PR TITLE
Use external repoman

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,14 @@
 #
 language: python
 python:
-    - pypy
+    - pypy3.5
 env:
-    - PORTAGE_VER="2.3.38"
+    global:
+        - PORTAGE_VER="2.3.38"
+        - REPOMAN_VER="2.3.9"
 before_install:
     - sudo apt-get -qq update
-    - pip install lxml pyyaml
+    - pip install lxml==4.1.1 pyyaml
 before_script:
     - sudo chmod a+rwX /etc/passwd /etc/group /etc /usr
     - mkdir -p travis-overlay /etc/portage /usr/portage/distfiles
@@ -18,6 +20,7 @@ before_script:
     - wget "https://raw.githubusercontent.com/mrueg/repoman-travis/master/.travis.yml" -O .travis.yml.upstream
     - wget "https://raw.githubusercontent.com/mrueg/repoman-travis/master/spinner.sh"
     - wget -qO - "https://github.com/gentoo/portage/archive/portage-${PORTAGE_VER}.tar.gz" | tar xz
+    - wget -qO - "https://github.com/gentoo/portage/archive/repoman-${REPOMAN_VER}.tar.gz" | tar xz
     - wget -qO - "https://github.com/gentoo-mirror/gentoo/archive/master.tar.gz" | tar xz -C /usr/portage --strip-components=1
     - chmod a+rwx spinner.sh
     - echo "portage:x:250:250:portage:/var/tmp/portage:/bin/false" >> /etc/passwd
@@ -29,5 +32,5 @@ before_script:
     - if ! cmp -n $SIZE -s .travis.yml .travis.yml.upstream; then echo -e "\e[31m !!! .travis.yml outdated! Update available https://github.com/mrueg/repoman-travis \e[0m" > /tmp/update ; fi
     - cd travis-overlay
 script:
-    - ./../spinner.sh "python ../portage-portage-${PORTAGE_VER}/repoman/bin/repoman full -d"
+    - ./../spinner.sh "python ../portage-repoman-${REPOMAN_VER}/repoman/bin/repoman full -d"
 # You can append own scripts after this line


### PR DESCRIPTION
Repoman was splitted out of portage as external release some time ago.
A copy of repoman is still shipped within portage, but this may change
in the upcoming releases.