### PR TITLE
Fix symlink bug and update Portage version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ language: python
 python:
     - pypy
 env:
-    - PORTAGE_VER="2.3.16"
+    - PORTAGE_VER="2.3.17"
 before_install:
     - sudo apt-get -qq update
     - pip install lxml
@@ -23,7 +23,7 @@ before_script:
     - echo "portage:x:250:250:portage:/var/tmp/portage:/bin/false" >> /etc/passwd
     - echo "portage::250:portage,travis" >> /etc/group
     - wget "https://www.gentoo.org/dtd/metadata.dtd" -O /usr/portage/distfiles/metadata.dtd
-    - ln -s portage-portage-${PORTAGE_VER}/cnf/repos.conf /etc/portage/repos.conf
+    - ln -s $TRAVIS_BUILD_DIR/portage-portage-${PORTAGE_VER}/cnf/repos.conf /etc/portage/repos.conf
     - ln -s /usr/portage/profiles/default/linux/amd64/13.0 /etc/portage/make.profile
     - SIZE=$(stat -c %s .travis.yml.upstream)
     - if ! cmp -n $SIZE -s .travis.yml .travis.yml.upstream; then echo -e "\e[31m !!! .travis.yml outdated! Update available https://github.com/mrueg/repoman-travis \e[0m" > /tmp/update ; fi


### PR DESCRIPTION
A symlink is made from the official Portage repos.conf
to repos.conf in /etc/portage, however an absolute path is not used.
This means that the symlink has a relative path and does not point
to the intended location.  This commit fixes that by using an absolute
path for the symlink, producing the intended result.

Also, update the PORTAGE_VER to 2.3.17