### PR TITLE
Configure portage directory (fix #40)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ language: python
 python:
     - pypy
 env:
-    - PORTAGE_VER="2.3.65"
+    - PORTAGE_VER="2.3.65" PORTDIR=/usr/portage
 before_install:
     - sudo apt-get -qq update
     - pip install lxml pyyaml


### PR DESCRIPTION
Default portage directory location is `/var/db/repos/gentoo` since
=sys/apps/portage-2.3.64.

I tried fixing #40 by creating that directory and extracting the archive
to that new location, but it doesn't seem to be writable when using
Travis CI.

So I chose to set `PORTDIR` instead, and that seems to fix my builds.

Please review, and let me know if there's a better approach to follow.