### PR TITLE
Update default portage directories (fix #40)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,20 +11,20 @@ before_install:
     - sudo apt-get -qq update
     - pip install lxml pyyaml
 before_script:
-    - sudo chmod a+rwX /etc/passwd /etc/group /etc /usr
-    - mkdir -p travis-overlay /etc/portage /usr/portage/distfiles
+    - sudo chmod a+rwX /etc/passwd /etc/group /etc /var /var/cache
+    - mkdir -p travis-overlay /etc/portage /var/cache/distfiles /var/db/repos/gentoo
     - mv !(travis-overlay) travis-overlay/
     - mv .git travis-overlay/
     - wget "https://raw.githubusercontent.com/mrueg/repoman-travis/master/.travis.yml" -O .travis.yml.upstream
     - wget "https://raw.githubusercontent.com/mrueg/repoman-travis/master/spinner.sh"
     - wget -qO - "https://github.com/gentoo/portage/archive/portage-${PORTAGE_VER}.tar.gz" | tar xz
-    - wget -qO - "https://github.com/gentoo-mirror/gentoo/archive/master.tar.gz" | tar xz -C /usr/portage --strip-components=1
+    - wget -qO - "https://github.com/gentoo-mirror/gentoo/archive/master.tar.gz" | tar xz -C /var/db/repos/gentoo --strip-components=1
     - chmod a+rwx spinner.sh
     - echo "portage:x:250:250:portage:/var/tmp/portage:/bin/false" >> /etc/passwd
     - echo "portage::250:portage,travis" >> /etc/group
-    - wget "https://www.gentoo.org/dtd/metadata.dtd" -O /usr/portage/distfiles/metadata.dtd
+    - wget "https://www.gentoo.org/dtd/metadata.dtd" -O /var/cache/distfiles/metadata.dtd
     - ln -s $TRAVIS_BUILD_DIR/portage-portage-${PORTAGE_VER}/cnf/repos.conf /etc/portage/repos.conf
-    - ln -s /usr/portage/profiles/default/linux/amd64/17.0 /etc/portage/make.profile
+    - ln -s /var/db/repos/gentoo/profiles/default/linux/amd64/17.0 /etc/portage/make.profile
     - SIZE=$(stat -c %s .travis.yml.upstream)
     - if ! cmp -n $SIZE -s .travis.yml .travis.yml.upstream; then echo -e "\e[31m !!! .travis.yml outdated! Update available https://github.com/mrueg/repoman-travis \e[0m" > /tmp/update ; fi
     - cd travis-overlay


### PR DESCRIPTION
Make sure the new default portage directories introduced in
=sys-apps/portage-2.3.64 are present and used.

This PR replaces #41, which felt like more of a workaround.

Please review, and let me know if it needs further tweaks :)